### PR TITLE
Adds support for *.sam.gz and *.sam.xz in calculate_coverage.py

### DIFF
--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -30,9 +30,15 @@ def calculate_coverages(input, output, database):
         if samfile.endswith(".sam"):
             open_sam_file = open(samfile.strip(), 'r')
         elif samfile.endswith(".sam.gz"):
-            open_sam_file = gzip.open(samfile.strip(), 'r')
+            open_sam_file = gzip.open(
+                samfile.strip(),
+                mode='rt',
+                encoding='utf-8')
         elif samfile.endswith(".sam.xz"):
-            open_sam_file = lzma.open(samfile.strip(), 'r')
+            open_sam_file = lzma.open(
+                samfile.strip(),
+                mode='rt',
+                encoding='utf-8')
 
         with open_sam_file:
             for line in open_sam_file:

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -39,7 +39,8 @@ def calculate_coverages(input, output, database):
                 samfile.strip(),
                 mode='rt',
                 encoding='utf-8')
-
+else:
+    raise IOError("Unrecognized file extension on '%s'." % samfile)
         with open_sam_file:
             for line in open_sam_file:
                 #Get values for contig, location, and length

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -39,8 +39,8 @@ def calculate_coverages(input, output, database):
                 samfile.strip(),
                 mode='rt',
                 encoding='utf-8')
-else:
-    raise IOError("Unrecognized file extension on '%s'." % samfile)
+        else:
+            raise IOError("Unrecognized file extension on '%s'." % samfile)
         with open_sam_file:
             for line in open_sam_file:
                 #Get values for contig, location, and length

--- a/filter_sam.py
+++ b/filter_sam.py
@@ -6,34 +6,69 @@ import pandas as pd
 from glob import glob
 import sys
 import os
+import gzip
+import lzma
+
+
+def open_sam(samfile, mode):
+    if samfile.endswith(".sam"):
+        open_sam_file = open(samfile.strip(), mode)
+    elif samfile.endswith(".sam.gz"):
+        open_sam_file = gzip.open(
+            samfile.strip(),
+            mode=mode,
+            encoding='utf-8')
+    elif samfile.endswith(".sam.xz"):
+        open_sam_file = lzma.open(
+            samfile.strip(),
+            mode=mode,
+            encoding='utf-8')
+    else:
+        raise IOError("Unrecognized file extension on '%s'." % samfile)
+    return open_sam_file
+
+
+def open_files(in_file, out_file):
+    in_fd = open_sam(in_file, "rt")
+    out_fd = open_sam(out_file, "wt")
+    return in_fd, out_fd
 
 @click.command()
 @click.option('--input','-i', help='Input coverage .tsv file generated from calculate_coverages.py.', required=True)
 @click.option('--sam','-s', help='Sam file to filter or directory of sam files to filter.',required=True)
 @click.option('--cutoff','-c', default=0.1, help='Minimum % genome coverage.', show_default=True)
 @click.option('--output','-o', help='Output directory to write output files. Will be created if does not exist.', required=True)
-
-
 def filter_sam(input, sam, cutoff, output):
     #Add / to end of output dir if not present
     output = output.rstrip('/') + '/'
     #Remove / from end of sam if present
     sam = sam.rstrip('/')
+
+    sam_file_list = []
+    sam_xz_file_list = []
+    sam_gz_file_list = []
     if os.path.isdir(sam):
-        sam_file_list=glob(sam + "/*.sam")
-        if not sam_file_list:
-            print("No sam files found in folder (.sam extensions required).")
+        sam_file_list = glob(sam + "/*.sam")
+        sam_xz_file_list = glob(sam + "/*.sam.xz")
+        sam_gz_file_list = glob(sam + "/*.sam.gz")
+        if not sam_file_list and not sam_xz_file_list and not sam_gz_file_list:
+            print("No sam files found in folder (.sam/.sam.xz/.sam.gz extensions required).")
             sys.exit(1)
-    elif sam.split('.')[-1]=="sam":
-        sam_file_list=[sam]
+    elif sam.endswith(".sam"):
+        sam_file_list = [sam]
+    elif sam.endswith(".sam.gz"):
+        sam_gz_file_list = [sam]
+    elif sam.endswith(".sam.xz"):
+        sam_xz_file_list = [sam]
     else:
-        print("Sam input requires either a sam file (with .sam extenstion) or a directory of sam files.")
+        print("Sam input requires either a sam file (with .sam/.sam.xz/.sam.gz extension) or a directory of sam files.")
         sys.exit(1)
-    #Create output directory if it doesn't exist
+
+    sam_file_list = sam_file_list + sam_gz_file_list + sam_xz_file_list
+
+    # Create output directory if it doesn't exist
     if not os.path.exists(output):
         os.makedirs(output)
-    #Make output names
-    sam_output_names = [output + file.split('/')[-1].replace(".sam",'_filtered.sam') for file in sam_file_list]
 
     #Get taxa to keep
     coverage_df = pd.read_table(input)
@@ -41,10 +76,15 @@ def filter_sam(input, sam, cutoff, output):
 
     #Filter sam file(s)
     for i in range(len(sam_file_list)):
-        with open(sam_file_list[i], 'r') as openin, open(sam_output_names[i], 'w') as openout:
+        in_file = sam_file_list[i]
+        out_file = output + in_file.split('/')[-1].replace(".sam", '_filtered.sam')
+
+        openin, openout = open_files(in_file, out_file)
+        with openin, openout:
             for line in openin:
                 if line.split('\t')[2] in taxa_to_keep:
                     openout.write(line)
+
 
 if __name__ == "__main__":
     filter_sam()

--- a/test_data/README.txt
+++ b/test_data/README.txt
@@ -1,0 +1,3 @@
+filtered sample alignments can be generated using a threshold of 0.00085 (ie, take top 5 species from sample_output.tsv)
+
+python ../filter_sam.py -i sample_output.tsv -s sample_alignments/ -c 0.00085 -o ./filtered_sample_alignments


### PR DESCRIPTION
Right now this only works for calculate_coverage.py.  I think making something similar for filter_sam would be straightforward, definitely easy to add this exact change to read in files, but I didn't feel comfortable deciding whether output files should be zipped or not matching the input files.  

Let me know if you want something like this and I'm happy to help add it in.   