### PR TITLE
Hashset to ranges

### DIFF
--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -30,6 +30,7 @@ def calculate_coverages(input, output, database):
                 #Add range to contig_dict
                 for i in range(location,location+length):
                     gotu_dict[gotu].add(i)
+            print(len(gotu_dict))
 
 
     ###################################

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -43,8 +43,12 @@ def calculate_coverages(input, output, database):
     #Calculate coverages#
     #####################
     #Make dataframe from dicitonary of coverages of each contig
-    cov = pd.DataFrame({"gotu":list(gotu_dict.keys()),
-                        "covered_length" : [len(x) for x in gotu_dict.values()] } )
+    cov = pd.DataFrame(
+        {
+            "gotu": list(gotu_dict.keys()),
+            "covered_length": [x.compute_length() for x in gotu_dict.values()]
+        }
+    )
     cov= cov.set_index("gotu")
     cov = cov.sort_values("covered_length", ascending=False)
     #Add genome metadata

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -30,7 +30,11 @@ def calculate_coverages(input, output, database):
                 #Add range to contig_dict
                 for i in range(location,location+length):
                     gotu_dict[gotu].add(i)
-            print(len(gotu_dict))
+            print("Num GOTUs", len(gotu_dict))
+            sumsize = 0
+            for gotu in gotu_dict:
+                sumsize += len(gotu_dict[gotu])
+            print("Rough mem size:", sumsize)
 
 
     ###################################

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -5,6 +5,7 @@ from sys import argv
 from os import path
 import click
 from glob import glob
+from cover import SortedRangeList
 
 @click.command()
 @click.option('-i',"--input", required=True, help="Input: Directory of sam files (files must end in .sam).")
@@ -15,7 +16,7 @@ def calculate_coverages(input, output, database):
     ###################################
     #Calculate coverage of each contig#
     ###################################
-    gotu_dict = defaultdict(set)
+    gotu_dict = defaultdict(SortedRangeList)
     file_list = glob(input + "/*.sam")
     for samfile in file_list:
         with open(samfile.strip(), 'r') as open_sam_file:
@@ -28,12 +29,11 @@ def calculate_coverages(input, output, database):
                 length_string = linesplit[5]
                 length = sum([int(x) for x in re.split("[a-zA-Z]",length_string) if x])
                 #Add range to contig_dict
-                for i in range(location,location+length):
-                    gotu_dict[gotu].add(i)
+                gotu_dict[gotu].add_range(location, location + length - 1)
             print("Num GOTUs", len(gotu_dict))
             sumsize = 0
             for gotu in gotu_dict:
-                sumsize += len(gotu_dict[gotu])
+                sumsize += len(gotu_dict[gotu].ranges)
             print("Rough mem size:", sumsize)
 
 

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -30,11 +30,6 @@ def calculate_coverages(input, output, database):
                 length = sum([int(x) for x in re.split("[a-zA-Z]",length_string) if x])
                 #Add range to contig_dict
                 gotu_dict[gotu].add_range(location, location + length - 1)
-            print("Num GOTUs", len(gotu_dict))
-            sumsize = 0
-            for gotu in gotu_dict:
-                sumsize += len(gotu_dict[gotu].ranges)
-            print("Rough mem size:", sumsize)
 
 
     ###################################

--- a/cover.py
+++ b/cover.py
@@ -5,7 +5,7 @@ class SortedRangeList:
         self.since_compressed = 0
 
     def add_range(self, start, end):
-        self.ranges.append((start,end))
+        self.ranges.append((start, end))
         self.since_compressed += 1
         if self.autocompress is not None and \
                 self.since_compressed > self.autocompress:

--- a/cover.py
+++ b/cover.py
@@ -1,0 +1,73 @@
+class RangeNode:
+    def __init__(self, val, is_start):
+        self.val = val
+        self.is_start = is_start
+        self.other = None
+
+    def length(self):
+        if self.is_start:
+            return self.other.val - self.val + 1
+        else:
+            return self.val - self.other.val + 1
+
+
+class IndexRange:
+    # start_val and end_val are both inclusive.
+    # IndexRange(1,1) is length 1
+    # IndexRange(1,0) is invalid
+    def __init__(self, start_val, end_val):
+        self.start = RangeNode(start_val, True)
+        self.end = RangeNode(end_val, False)
+        self.start.other = self.end
+        self.end.other = self.start
+
+
+class SortedRangeList:
+    def __init__(self):
+        self.nodes = []
+
+    def add_range(self, range):
+        if range.end.val < range.start.val:
+            return
+        self.nodes.append(range.start)
+
+    def compress(self):
+        # We sort such that start nodes come before end nodes of the same value
+        self.nodes.sort(key=lambda x: x.val * 2 - x.is_start)
+
+        new_nodes = []
+        start_val = None
+        end_val = None
+
+        for node in self.nodes:
+            if end_val is None:
+                # case 1: no active node, start active node.
+                start_val = node.val
+                end_val = node.other.val
+            elif end_val >= node.val - 1:
+                # case 2: active node continues through this range
+                # extend active range
+                end_val = max(end_val, node.other.val)
+            else:  # if end_val < node.val - 1:
+                # case 3: active node ends before this range begins
+                # write new node out, then start new active node
+                new_range = IndexRange(start_val, end_val)
+                new_nodes.append(new_range.start)
+                start_val = node.val
+                end_val = node.other.val
+
+        if end_val is not None:
+            new_range = IndexRange(start_val, end_val)
+            new_nodes.append(new_range.start)
+
+        self.nodes = new_nodes
+
+    def compute_length(self):
+        total = 0
+        for node in self.nodes:
+            total += node.length()
+        return total
+
+    def __str__(self):
+        pairs = [(node.val, node.other.val) for node in self.nodes]
+        return str(pairs)

--- a/cover.py
+++ b/cover.py
@@ -1,30 +1,21 @@
-class IndexRange:
-    __slots__ = ['start', 'end']
-
-    # start and end are both inclusive.
-    # IndexRange(1,1) is length 1
-    # IndexRange(1,0) is invalid
-    def __init__(self, start, end):
-        self.start = start
-        self.end = end
-
-    def __repr__(self):
-        return str((self.start, self.end))
-
-    def __len__(self):
-        return self.end - self.start + 1
-
-
 class SortedRangeList:
-    def __init__(self):
+    def __init__(self, autocompress=100000):
         self.ranges = []
+        self.autocompress = autocompress
+        self.since_compressed = 0
 
-    def add_range(self, range):
-        self.ranges.append(range)
+    def add_range(self, start, end):
+        self.ranges.append((start,end))
+        self.since_compressed += 1
+        if self.autocompress is not None and \
+                self.since_compressed > self.autocompress:
+            self.compress()
 
     def compress(self):
+        if self.since_compressed == 0:
+            return
         # Sort ranges by start index
-        self.ranges.sort(key=lambda r: r.start)
+        self.ranges.sort(key=lambda r: r[0])
 
         new_ranges = []
         start_val = None
@@ -33,30 +24,33 @@ class SortedRangeList:
         for r in self.ranges:
             if end_val is None:
                 # case 1: no active range, start active range.
-                start_val = r.start
-                end_val = r.end
-            elif end_val >= r.start - 1:
+                start_val = r[0]
+                end_val = r[1]
+            elif end_val >= r[0] - 1:
                 # case 2: active range continues through this range
                 # extend active range
-                end_val = max(end_val, r.end)
-            else:  # if end_val < range.start - 1:
+                end_val = max(end_val, r[1])
+            else:  # if end_val < r[0] - 1:
                 # case 3: active range ends before this range begins
                 # write new range out, then start new active range
-                new_range = IndexRange(start_val, end_val)
+                new_range = (start_val, end_val)
                 new_ranges.append(new_range)
-                start_val = r.start
-                end_val = r.end
+                start_val = r[0]
+                end_val = r[1]
 
         if end_val is not None:
-            new_range = IndexRange(start_val, end_val)
+            new_range = (start_val, end_val)
             new_ranges.append(new_range)
 
         self.ranges = new_ranges
+        self.since_compressed = 0
 
     def compute_length(self):
+        if self.since_compressed > 0:
+            self.compress()
         total = 0
         for r in self.ranges:
-            total += len(r)
+            total += r[1] - r[0] + 1
         return total
 
     def __str__(self):

--- a/cover.py
+++ b/cover.py
@@ -1,4 +1,6 @@
 class IndexRange:
+    __slots__ = ['start', 'end']
+
     # start and end are both inclusive.
     # IndexRange(1,1) is length 1
     # IndexRange(1,0) is invalid

--- a/cover.py
+++ b/cover.py
@@ -1,73 +1,61 @@
-class RangeNode:
-    def __init__(self, val, is_start):
-        self.val = val
-        self.is_start = is_start
-        self.other = None
-
-    def length(self):
-        if self.is_start:
-            return self.other.val - self.val + 1
-        else:
-            return self.val - self.other.val + 1
-
-
 class IndexRange:
-    # start_val and end_val are both inclusive.
+    # start and end are both inclusive.
     # IndexRange(1,1) is length 1
     # IndexRange(1,0) is invalid
-    def __init__(self, start_val, end_val):
-        self.start = RangeNode(start_val, True)
-        self.end = RangeNode(end_val, False)
-        self.start.other = self.end
-        self.end.other = self.start
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __repr__(self):
+        return str((self.start, self.end))
+
+    def __len__(self):
+        return self.end - self.start + 1
 
 
 class SortedRangeList:
     def __init__(self):
-        self.nodes = []
+        self.ranges = []
 
     def add_range(self, range):
-        if range.end.val < range.start.val:
-            return
-        self.nodes.append(range.start)
+        self.ranges.append(range)
 
     def compress(self):
-        # We sort such that start nodes come before end nodes of the same value
-        self.nodes.sort(key=lambda x: x.val * 2 - x.is_start)
+        # Sort ranges by start index
+        self.ranges.sort(key=lambda r: r.start)
 
-        new_nodes = []
+        new_ranges = []
         start_val = None
         end_val = None
 
-        for node in self.nodes:
+        for r in self.ranges:
             if end_val is None:
-                # case 1: no active node, start active node.
-                start_val = node.val
-                end_val = node.other.val
-            elif end_val >= node.val - 1:
-                # case 2: active node continues through this range
+                # case 1: no active range, start active range.
+                start_val = r.start
+                end_val = r.end
+            elif end_val >= r.start - 1:
+                # case 2: active range continues through this range
                 # extend active range
-                end_val = max(end_val, node.other.val)
-            else:  # if end_val < node.val - 1:
-                # case 3: active node ends before this range begins
-                # write new node out, then start new active node
+                end_val = max(end_val, r.end)
+            else:  # if end_val < range.start - 1:
+                # case 3: active range ends before this range begins
+                # write new range out, then start new active range
                 new_range = IndexRange(start_val, end_val)
-                new_nodes.append(new_range.start)
-                start_val = node.val
-                end_val = node.other.val
+                new_ranges.append(new_range)
+                start_val = r.start
+                end_val = r.end
 
         if end_val is not None:
             new_range = IndexRange(start_val, end_val)
-            new_nodes.append(new_range.start)
+            new_ranges.append(new_range)
 
-        self.nodes = new_nodes
+        self.ranges = new_ranges
 
     def compute_length(self):
         total = 0
-        for node in self.nodes:
-            total += node.length()
+        for r in self.ranges:
+            total += len(r)
         return total
 
     def __str__(self):
-        pairs = [(node.val, node.other.val) for node in self.nodes]
-        return str(pairs)
+        return str(self.ranges)

--- a/cover_test.py
+++ b/cover_test.py
@@ -1,20 +1,20 @@
-from cover import SortedRangeList, IndexRange
+from cover import SortedRangeList
 import random
 from time import perf_counter
 
-srl = SortedRangeList()
-for i in range(9, 0, -2):
-    srl.add_range(IndexRange(i,i))
-print(srl)
-srl.add_range(IndexRange(4,4))
-print(srl)
-srl.compress()
-print(srl)
+
+def simple_test():
+    srl = SortedRangeList(autocompress=None)
+    for i in range(9, 0, -2):
+        srl.add_range(i,i)
+    srl.add_range(4,4)
+    srl.compress()
+    assert(str(srl) == "[(1, 1), (3, 5), (7, 7), (9, 9)]")
 
 
 def stress_test(seed, num_reads):
     intset = set()
-    srl = SortedRangeList()
+    srl = SortedRangeList(autocompress=None)
 
     start_set = perf_counter()
     random.seed(seed)
@@ -30,7 +30,7 @@ def stress_test(seed, num_reads):
     for i in range(num_reads):
         read_start = random.randint(0, 10000000)
         read_len = random.randint(85, 150)
-        srl.add_range(IndexRange(read_start, read_start+read_len-1))
+        srl.add_range(read_start, read_start+read_len-1)
     print("SRL_ADD: ", perf_counter() - start_srl)
     srl.compress()
     print("SRL_ADD AND COMPRESS: ", perf_counter() - start_srl)
@@ -39,8 +39,29 @@ def stress_test(seed, num_reads):
 
     print(srl_len)
     print(len(intset))
+    assert(len(intset) == srl_len)
     print(len(srl.ranges))
 
+
+def multi_compress_test(seed, num_reads):
+    srl = SortedRangeList(autocompress=None)
+
+    for compress_count in [1000, 10000, 100000]:
+        start_srl = perf_counter()
+        random.seed(seed)
+        for i in range(num_reads):
+            read_start = random.randint(0, 10000000)
+            read_len = random.randint(85, 150)
+            srl.add_range(read_start, read_start+read_len-1)
+            if i % compress_count == 0:
+                srl.compress()
+        print(srl.compute_length())
+        print("Compress Counter: ", compress_count, " Performance: ", perf_counter() - start_srl)
+
+
+simple_test()
 seed = 127
-for reads in [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000]:
+for reads in [1, 10, 100, 1000, 10000, 100000, 1000000]:
+    multi_compress_test(seed, reads)
+for reads in [1, 10, 100, 1000, 10000, 100000, 1000000]:
     stress_test(seed, reads)

--- a/cover_test.py
+++ b/cover_test.py
@@ -6,8 +6,8 @@ from time import perf_counter
 def simple_test():
     srl = SortedRangeList(autocompress=None)
     for i in range(9, 0, -2):
-        srl.add_range(i,i)
-    srl.add_range(4,4)
+        srl.add_range(i, i)
+    srl.add_range(4, 4)
     srl.compress()
     assert(str(srl) == "[(1, 1), (3, 5), (7, 7), (9, 9)]")
 
@@ -56,7 +56,8 @@ def multi_compress_test(seed, num_reads):
             if i % compress_count == 0:
                 srl.compress()
         print(srl.compute_length())
-        print("Compress Counter: ", compress_count, " Performance: ", perf_counter() - start_srl)
+        print("Compress Counter: ", compress_count,
+              " Performance: ", perf_counter() - start_srl)
 
 
 simple_test()

--- a/cover_test.py
+++ b/cover_test.py
@@ -39,7 +39,7 @@ def stress_test(seed, num_reads):
 
     print(srl_len)
     print(len(intset))
-    print(len(srl.nodes))
+    print(len(srl.ranges))
 
 seed = 127
 for reads in [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000]:

--- a/cover_test.py
+++ b/cover_test.py
@@ -1,0 +1,46 @@
+from cover import SortedRangeList, IndexRange
+import random
+from time import perf_counter
+
+srl = SortedRangeList()
+for i in range(9, 0, -2):
+    srl.add_range(IndexRange(i,i))
+print(srl)
+srl.add_range(IndexRange(4,4))
+print(srl)
+srl.compress()
+print(srl)
+
+
+def stress_test(seed, num_reads):
+    intset = set()
+    srl = SortedRangeList()
+
+    start_set = perf_counter()
+    random.seed(seed)
+    for i in range(num_reads):
+        read_start = random.randint(0, 10000000)
+        read_len = random.randint(85, 150)
+        for j in range(read_start, read_start + read_len):
+            intset.add(j)
+    print("SET_ADD: ", perf_counter() - start_set)
+
+    start_srl = perf_counter()
+    random.seed(seed)
+    for i in range(num_reads):
+        read_start = random.randint(0, 10000000)
+        read_len = random.randint(85, 150)
+        srl.add_range(IndexRange(read_start, read_start+read_len-1))
+    print("SRL_ADD: ", perf_counter() - start_srl)
+    srl.compress()
+    print("SRL_ADD AND COMPRESS: ", perf_counter() - start_srl)
+    srl_len = srl.compute_length()
+    print("SRL_ADD COMPRESS AND LENGTH: ", perf_counter() - start_srl)
+
+    print(srl_len)
+    print(len(intset))
+    print(len(srl.nodes))
+
+seed = 127
+for reads in [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000]:
+    stress_test(seed, reads)


### PR DESCRIPTION
When running calculate_coverage on several thousand .sam files, I noticed the memory usage was quite high, causing me to run out of memory.  I tracked usage to the sets of integers used to keep track of coverage.  

I've added two new files, cover.py and cover_test.py.  

cover.py implements a new data structure: SortedRangeList.  This takes inclusive integer ranges and maintains the total coverage of those ranges, automatically compressing its internal representation over time.  

cover_test.py is a collection of unit tests and performance test functions to compare it against the original hashset implementation.  

Theoretical performance from cover_test is about 3x faster with 1/100 memory usage for set operations.  
Real world performance is closer to 1.2-1.5x faster for the whole program, 1/10 memory usage.  

This takes it from ~40-50GB to ~4GB for the first set of files in my use case.   